### PR TITLE
Cherrypicked nofrendo optimizations from upstream

### DIFF
--- a/nofrendo-go/components/nofrendo/cpu/nes6502.c
+++ b/nofrendo-go/components/nofrendo/cpu/nes6502.c
@@ -1146,7 +1146,7 @@ IRAM_ATTR int nes6502_execute(int timeslice_cycles)
 
 #ifdef NES6502_JUMPTABLE
 
-   DRAM_ATTR static const void *opcode_table[256] =
+   const void *opcode_table[256] =
    {
       &&op0x00, &&op0x01, &&op0x02, &&op0x03, &&op0x04, &&op0x05, &&op0x06, &&op0x07,
       &&op0x08, &&op0x09, &&op0x0A, &&op0x0B, &&op0x0C, &&op0x0D, &&op0x0E, &&op0x0F,
@@ -1189,9 +1189,7 @@ IRAM_ATTR int nes6502_execute(int timeslice_cycles)
    /* check for DMA cycle burning */
    if (cpu.burn_cycles && remaining_cycles > 0)
    {
-      int burn_for;
-
-      burn_for = MIN(remaining_cycles, cpu.burn_cycles);
+      int burn_for = MIN(remaining_cycles, cpu.burn_cycles);
       ADD_CYCLES(burn_for);
       cpu.burn_cycles -= burn_for;
    }
@@ -1240,8 +1238,8 @@ IRAM_ATTR int nes6502_execute(int timeslice_cycles)
       OPCODE(0x1B, SLO(7, ABS_IND_Y, writebyte, addr));             /* SLO $nnnn,Y */
       OPCODE(0x1C, TOP());                                          /* NOP $nnnn,X */
       OPCODE(0x1D, ORA(4, ABS_IND_X_BYTE_READ));                    /* ORA $nnnn,X */
-      OPCODE(0x1E, ASL(7, ABS_IND_X, writebyte, addr));              /* ASL $nnnn,X */
-      OPCODE(0x1F, SLO(7, ABS_IND_X, writebyte, addr));              /* SLO $nnnn,X */
+      OPCODE(0x1E, ASL(7, ABS_IND_X, writebyte, addr));             /* ASL $nnnn,X */
+      OPCODE(0x1F, SLO(7, ABS_IND_X, writebyte, addr));             /* SLO $nnnn,X */
 
       OPCODE(0x20, JSR());                                          /* JSR $nnnn */
       OPCODE(0x21, AND(6, INDIR_X_BYTE));                           /* AND ($nn,X) */
@@ -1494,11 +1492,10 @@ IRAM_ATTR int nes6502_execute(int timeslice_cycles)
 void nes6502_reset(void)
 {
    cpu.p_reg = Z_FLAG | R_FLAG | I_FLAG;  /* Reserved bit always 1 */
-   cpu.int_pending = 0;                   /* No pending interrupts */
-   cpu.int_latency = 0;                   /* No latent interrupts */
    cpu.pc_reg = readword(RESET_VECTOR);   /* Fetch reset vector */
-   cpu.burn_cycles = RESET_CYCLES;
+   cpu.int_pending = false;               /* No pending interrupts */
    cpu.jammed = false;
+   cpu.burn_cycles = RESET_CYCLES;
 }
 
 /* Non-maskable interrupt */

--- a/nofrendo-go/components/nofrendo/cpu/nes6502.h
+++ b/nofrendo-go/components/nofrendo/cpu/nes6502.h
@@ -56,17 +56,17 @@
 typedef struct
 {
    uint32 pc_reg;
-   uint8 a_reg, p_reg;
+   uint8 a_reg;
    uint8 x_reg, y_reg;
-   uint8 s_reg;
+   uint8 s_reg, p_reg;
 
    uint8 *zp, *stack;
 
-   uint8 jammed;  /* is processor jammed? */
+   bool int_pending;
+   bool jammed;
 
-   uint8 int_pending, int_latency;
-
-   int32 total_cycles, burn_cycles;
+   long total_cycles;
+   long burn_cycles;
 } nes6502_t;
 
 #ifdef __cplusplus

--- a/nofrendo-go/main/main.c
+++ b/nofrendo-go/main/main.c
@@ -28,7 +28,7 @@ static odroid_video_frame_t *currentUpdate = &update1;
 static odroid_video_frame_t *previousUpdate = NULL;
 
 static int16_t audioBuffer[AUDIO_BUFFER_LENGTH * 2];
-static int16_t pendingSamples = 0;
+static int32_t pendingSamples = 0;
 
 static odroid_gamepad_state_t joystick1;
 static odroid_gamepad_state_t joystick2;
@@ -291,7 +291,7 @@ void osd_wait_for_vsync()
 */
 void osd_audioframe(int audioSamples)
 {
-   if (odroid_system_get_app()->speedupEnabled)
+   if (app->speedupEnabled)
       return;
 
    apu_process(audioBuffer, audioSamples); //get audio data


### PR DESCRIPTION
Patches used:
[NES: Small PPU optimization](https://github.com/ducalex/retro-go/commit/f7bd89158ef611c9e144ad4acba418ab591deaf1.patch)
[NES: 5% performance optimization by moving op table to the stack](https://github.com/ducalex/retro-go/commit/3d4b10327307506f937ac67796b4c906acf9d73e.patch)

There's an interesting patch that claims to reduce stuttering in SMB3 ([NES: APU optimization, reduces frameskip in SMB3](https://github.com/ducalex/retro-go/commit/b4f589e47e2e3717afe6c3b624b20a0c6d36215b.patch)), but it seems to mess with vsync and audio, so that would most likely require some changes in game-and-watch-retro-go.