### PR TITLE
remove section attributes

### DIFF
--- a/gnuboy-go/components/gnuboy/loader.c
+++ b/gnuboy-go/components/gnuboy/loader.c
@@ -200,7 +200,7 @@ static svar_t svars[] =
 #ifdef GB_CACHE_ROM
 
 #define BANK_NUM  32
-uint8_t banks[BANK_NUM][BANK_SIZE] __attribute__((section (".emulator_data")));
+uint8_t banks[BANK_NUM][BANK_SIZE];
 
 #endif
 
@@ -235,7 +235,7 @@ int IRAM_ATTR rom_loadbank(short bank)
 }
 
 //uint8_t sram[8192];
-uint8_t sram[8192 * 16] __attribute__((section (".emulator_data")));
+uint8_t sram[8192 * 16];
 
 static int gb_rom_load()
 {

--- a/gnuboy-go/components/gnuboy/mem.c
+++ b/gnuboy-go/components/gnuboy/mem.c
@@ -13,7 +13,7 @@
 
 struct mbc mbc;
 struct rom rom;
-struct ram ram __attribute__((section (".emulator_data")));
+struct ram ram;
 
 
 /*

--- a/nofrendo-go/components/nofrendo/nes/nes.c
+++ b/nofrendo-go/components/nofrendo/nes/nes.c
@@ -33,7 +33,7 @@
 
 #define NES_OVERDRAW (8)
 
-static uint8_t bitmap_data[2][sizeof(bitmap_t) + (sizeof(uint8 *) * NES_SCREEN_HEIGHT)]   __attribute__((section (".emulator_data")));;
+static uint8_t bitmap_data[2][sizeof(bitmap_t) + (sizeof(uint8 *) * NES_SCREEN_HEIGHT)];
 static bitmap_t *framebuffers[2];
 static nes_t nes;
 


### PR DESCRIPTION
The linker will deal with placing these arrays in the proper region.
(This is part of the 'multiple emulators' feature originally by
Thomas Roth <code@stacksmashing.net>)