### PR TITLE
smsplusgx: porting changes

### DIFF
--- a/smsplusgx-go/components/smsplus/cpu/z80.c
+++ b/smsplusgx-go/components/smsplus/cpu/z80.c
@@ -135,6 +135,13 @@
 #define LOG(x)
 #endif
 
+unsigned char *cpu_readmap[64];
+unsigned char *cpu_writemap[64];
+
+void (*cpu_writemem16)(int address, int data);
+void (*cpu_writeport16)(uint16 port, uint8 data);
+uint8 (*cpu_readport16)(uint16 port);
+
 int z80_cycle_count = 0;        /* running total of cycles executed */
 
 #define CF  0x01
@@ -2433,14 +2440,18 @@ ALWAYS_INLINE void take_interrupt(void)
 void z80_init(int index, int clock, const void *config, int (*irqcallback)(int))
 {
   int i, p;
+  static uint8 add_buf[2*256*256];
+  static uint8 sub_buf[2*256*256];
 
   if( !SZHVC_add || !SZHVC_sub )
   {
     int oldval, newval, val;
     UINT8 *padd, *padc, *psub, *psbc;
     /* allocate big flag arrays once */
-    SZHVC_add = (UINT8 *)malloc(2*256*256);
-    SZHVC_sub = (UINT8 *)malloc(2*256*256);
+    //SZHVC_add = (UINT8 *)malloc(2*256*256);
+    //SZHVC_sub = (UINT8 *)malloc(2*256*256);
+    SZHVC_add = add_buf;
+    SZHVC_sub = sub_buf;
     if( !SZHVC_add || !SZHVC_sub )
     {
       return;
@@ -2543,9 +2554,9 @@ void z80_reset(void)
 
 void z80_exit(void)
 {
-  if (SZHVC_add) free(SZHVC_add);
+  //if (SZHVC_add) free(SZHVC_add);
   SZHVC_add = NULL;
-  if (SZHVC_sub) free(SZHVC_sub);
+  //if (SZHVC_sub) free(SZHVC_sub);
   SZHVC_sub = NULL;
 }
 

--- a/smsplusgx-go/components/smsplus/cpu/z80.h
+++ b/smsplusgx-go/components/smsplus/cpu/z80.h
@@ -68,12 +68,12 @@ void z80_set_irq_line(int irqline, int state);
 void z80_reset_cycle_count(void);
 int z80_get_elapsed_cycles(void);
 
-unsigned char *cpu_readmap[64];
-unsigned char *cpu_writemap[64];
+extern unsigned char *cpu_readmap[64];
+extern unsigned char *cpu_writemap[64];
 
-void (*cpu_writemem16)(int address, int data);
-void (*cpu_writeport16)(uint16 port, uint8 data);
-uint8 (*cpu_readport16)(uint16 port);
+extern void (*cpu_writemem16)(int address, int data);
+extern void (*cpu_writeport16)(uint16 port, uint8 data);
+extern uint8 (*cpu_readport16)(uint16 port);
 
 
 

--- a/smsplusgx-go/components/smsplus/render.c
+++ b/smsplusgx-go/components/smsplus/render.c
@@ -25,6 +25,9 @@
 #include "shared.h"
 #include "hvc.h"
 
+/* This buffer used by the render code will also be re-used for saving the state to flash */
+uint32 glob_bp_lut[0x10000];
+
 struct
 {
   uint16 yrange;
@@ -210,7 +213,8 @@ void render_init(void)
   make_tms_tables();
 
   /* Generate 64k of data for the look up table */
-  uint8 *_lut = malloc(0x10000);
+  //uint8 *_lut = malloc(0x10000);
+  static uint8 _lut[0x10000] __attribute__((section (".ahb")));
 
   for(bx = 0; bx < 0x100; bx++)
   {
@@ -281,7 +285,8 @@ void render_init(void)
 
 
   /* Make bitplane to pixel lookup table */
-  uint32 *_bp_lut = malloc(0x10000 * 4);
+  //uint32 *_bp_lut = malloc(0x10000 * 4);
+  uint32 *_bp_lut = glob_bp_lut;
 
   for(i = 0; i < 0x100; i++)
   for(j = 0; j < 0x100; j++)

--- a/smsplusgx-go/components/smsplus/shared.h
+++ b/smsplusgx-go/components/smsplus/shared.h
@@ -18,7 +18,7 @@ typedef signed long int int32;
 #include <math.h>
 #include <limits.h>
 //#include <zlib.h>
-#include <esp_attr.h>
+#include <porting.h>
 
 #ifndef PATH_MAX
 #ifdef  MAX_PATH
@@ -42,7 +42,7 @@ typedef signed long int int32;
 #include "emu2413.h"
 #include "ym2413.h"
 #include "fmintf.h"
-#include "sound.h"
+#include "sms_sound.h"
 #include "system.h"
 #include "loadrom.h"
 // #include "config.h"

--- a/smsplusgx-go/components/smsplus/sound/sms_sound.c
+++ b/smsplusgx-go/components/smsplus/sound/sms_sound.c
@@ -170,7 +170,7 @@ void sound_shutdown(void)
 }
 
 
-void sound_reset(void)
+void sms_sound_reset(void)
 {
   if(!snd.enabled)
     return;

--- a/smsplusgx-go/components/smsplus/sound/sms_sound.h
+++ b/smsplusgx-go/components/smsplus/sound/sms_sound.h
@@ -25,6 +25,9 @@
 #ifndef _SOUND_H_
 #define _SOUND_H_
 
+#define snd sms_snd
+#define snd_t sms_snd_t
+
 enum {
   STREAM_PSG_L, /* PSG left channel */
   STREAM_PSG_R, /* PSG right channel */
@@ -62,7 +65,7 @@ void fmunit_detect_w(int data);
 void fmunit_write(int offset, int data);
 int sound_init(void);
 void sound_shutdown(void);
-void sound_reset(void);
+void sms_sound_reset(void);
 void sound_update(int line);
 void sound_mixer_callback(int16 **stream, int16 **output, int length);
 

--- a/smsplusgx-go/components/smsplus/state.c
+++ b/smsplusgx-go/components/smsplus/state.c
@@ -39,6 +39,17 @@ system_save_state: sizeof Z80=72
 system_save_state: sizeof SN76489_Context=92
 */
 
+#define _fread(buffer, size, count, ptr) do {        \
+   memcpy(buffer, ptr, size * count);                \
+   ptr += size * count;                              \
+} while(0)
+
+// TODO: Jeopardy: What is bounds checking
+#define _fwrite(buffer, size, count, ptr) do {       \
+   memcpy(ptr, buffer, size * count);                \
+   ptr += size * count;                              \
+} while(0)
+
 int system_save_state(void *mem)
 {
   int i;
@@ -49,22 +60,22 @@ int system_save_state(void *mem)
   printf("%s: sizeof SN76489_Context=%d\n", __func__, sizeof(SN76489_Context));
 
   /*** Save SMS Context ***/
-  fwrite(&sms, sizeof(sms), 1, mem);
+  _fwrite(&sms, sizeof(sms), 1, mem);
 
   /*** Save VDP state ***/
-  fwrite(&vdp, sizeof(vdp), 1, mem);
+  _fwrite(&vdp, sizeof(vdp), 1, mem);
 
   /*** Save cart info ***/
   for (i = 0; i < 4; i++)
   {
-    fwrite(&cart.fcr[i], 1, 1, mem);
+    _fwrite(&cart.fcr[i], 1, 1, mem);
   }
 
   /*** Save SRAM ***/
-  fwrite(&cart.sram[0], 0x8000, 1, mem);
+  _fwrite(&cart.sram[0], 0x8000, 1, mem);
 
   /*** Save Z80 Context ***/
-  fwrite(&Z80, sizeof(Z80), 1, mem);
+  _fwrite(&Z80, sizeof(Z80), 1, mem);
 
 #if 0
   /*** Save YM2413 ***/
@@ -73,7 +84,7 @@ int system_save_state(void *mem)
 #endif
 
   /*** Save SN76489 ***/
-  fwrite(SN76489_GetContextPtr(0), SN76489_GetContextSize(), 1, mem);
+  _fwrite(SN76489_GetContextPtr(0), SN76489_GetContextSize(), 1, mem);
 
   return 0;
 }
@@ -93,7 +104,7 @@ void system_load_state(void *mem)
 
   /*** Set SMS Context ***/
   sms_t sms_tmp;
-  fread(&sms_tmp, sizeof(sms_tmp), 1, mem);
+  _fread(&sms_tmp, sizeof(sms_tmp), 1, mem);
   if(sms.console != sms_tmp.console)
   {
       system_reset();
@@ -103,7 +114,7 @@ void system_load_state(void *mem)
   sms = sms_tmp;
 
   /*** Set vdp state ***/
-  fread(&vdp, sizeof(vdp), 1, mem);
+  _fread(&vdp, sizeof(vdp), 1, mem);
 
 
 
@@ -114,15 +125,15 @@ void system_load_state(void *mem)
   /*** Set cart info ***/
   for (i = 0; i < 4; i++)
   {
-    fread(&cart.fcr[i], 1, 1, mem);
+    _fread(&cart.fcr[i], 1, 1, mem);
   }
 
   /*** Set SRAM ***/
-  fread(&cart.sram[0], 0x8000, 1, mem);
+  _fread(&cart.sram[0], 0x8000, 1, mem);
 
   /*** Set Z80 Context ***/
   int (*irq_cb)(int) = Z80.irq_callback;
-  fread(&Z80, sizeof(Z80), 1, mem);
+  _fread(&Z80, sizeof(Z80), 1, mem);
   Z80.irq_callback = irq_cb;
 
 #if 0
@@ -140,7 +151,7 @@ void system_load_state(void *mem)
   float psg_dClock = psg->dClock;
 
   /*** Set SN76489 ***/
-  fread(SN76489_GetContextPtr(0), SN76489_GetContextSize(), 1, mem);
+  _fread(SN76489_GetContextPtr(0), SN76489_GetContextSize(), 1, mem);
 
   // Restore clock rate
   psg->Clock = psg_Clock;

--- a/smsplusgx-go/components/smsplus/system.c
+++ b/smsplusgx-go/components/smsplus/system.c
@@ -168,7 +168,7 @@ void system_reset(void)
   pio_reset();
   vdp_reset();
   render_reset();
-  sound_reset();
+  sms_sound_reset();
 }
 
 void system_poweron(void)

--- a/smsplusgx-go/components/smsplus/tms.c
+++ b/smsplusgx-go/components/smsplus/tms.c
@@ -24,11 +24,11 @@
 
 int text_counter;               /* Text offset counter */
 
-static uint8 mc_lookup[16][256][8];    /* Expand BD, PG data into 8-bit pixels (MC) */
-static uint8 tms_lookup[16][256][2];   /* Expand BD, PG data into 8-bit pixels (G1,G2) */
-static uint8 tms_obj_lut[16*256];      /* Look up priority between SG and display pixels */
-static uint8 txt_lookup[256][2];       /* Expand BD, PG data into 8-bit pixels (TX) */
-static uint8 bp_expand[256][8];        /* Expand PG data into 8-bit pixels */
+static uint8 mc_lookup[16][256][8] __attribute__((section (".ahb")));    /* Expand BD, PG data into 8-bit pixels (MC) */
+static uint8 tms_lookup[16][256][2] __attribute__((section (".ahb")));   /* Expand BD, PG data into 8-bit pixels (G1,G2) */
+static uint8 tms_obj_lut[16*256] __attribute__((section (".ahb")));      /* Look up priority between SG and display pixels */
+static uint8 txt_lookup[256][2] __attribute__((section (".ahb")));       /* Expand BD, PG data into 8-bit pixels (TX) */
+static uint8 bp_expand[256][8] __attribute__((section (".ahb")));        /* Expand PG data into 8-bit pixels */
 
 static const uint8 diff_mask[]  = {0x07, 0x07, 0x0F, 0x0F};
 static const uint8 name_mask[]  = {0xFF, 0xFF, 0xFC, 0xFC};


### PR DESCRIPTION
- renamed sound.[ch] to sms_sound.[ch] to avoid name-clash.
- replaced mallocs by static buffers (mostly placed in .ahb memory)
- made a large array in the render code global to re-use is for state
  saving.