### PR TITLE
GW Issue 101: Remember the last selected game in the menu after reset

### DIFF
--- a/components/odroid/odroid_settings.h
+++ b/components/odroid/odroid_settings.h
@@ -41,6 +41,12 @@ void odroid_settings_StartupFile_set(void *value);
 uint16_t odroid_settings_MainMenuTimeoutS_get(void);
 void odroid_settings_MainMenuTimeoutS_set(uint16_t value);
 
+uint16_t odroid_settings_MainMenuSelectedTab_get(void);
+void odroid_settings_MainMenuSelectedTab_set(uint16_t value);
+
+uint16_t odroid_settings_MainMenuCursor_get(void);
+void odroid_settings_MainMenuCursor_set(uint16_t value);
+
 ODROID_START_ACTION odroid_settings_StartAction_get();
 void odroid_settings_StartAction_set(ODROID_START_ACTION value);
 


### PR DESCRIPTION
Part of https://github.com/kbeckmann/game-and-watch-retro-go/issues/101

Add two extra variables to odroid settings:
 - main_menu_selected_tab
 - main_menu_cursor

Instead of uint8_t array with tab name I had to use tab index